### PR TITLE
Fix typo

### DIFF
--- a/scribblings/eval.scrbl
+++ b/scribblings/eval.scrbl
@@ -12,7 +12,7 @@
 
 @title[#:tag "eval"]{Evaluation}
 
-This library provides utilities for building and runnign C programs with
+This library provides utilities for building and running C programs with
 a system-installed C compiler. Currently the only supported compiler is
 @link["http://gcc.gnu.org"]{GCC}.
 


### PR DESCRIPTION
`s/runnign/running/`